### PR TITLE
Migrate from Laravel Mix to Vite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /node_modules
 /public/catalog
 /public/hot
+/public/build
 /public/storage
 /public/themes
 /public/upload

--- a/innopacks/front/resources/js/bootstrap.js
+++ b/innopacks/front/resources/js/bootstrap.js
@@ -3,7 +3,8 @@ window.axios = axios;
 
 import $ from 'jquery';
 window.$ = window.jquery = $;
-window.jQuery = require('jquery');
+import jQuery from 'jquery';
+window.jQuery = jQuery;
 
 window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
 window.axios.defaults.headers.common['CSRF-TOKEN'] = $('meta[name="csrf-token"]').attr('content');

--- a/package.json
+++ b/package.json
@@ -1,13 +1,8 @@
 {
     "private": true,
     "scripts": {
-        "dev": "npm run development",
-        "development": "mix",
-        "watch": "mix watch",
-        "watch-poll": "mix watch -- --watch-options-poll=1000",
-        "hot": "mix watch --hot",
-        "prod": "npm run production",
-        "production": "mix --production"
+        "dev": "vite",
+        "build": "vite build"
     },
     "devDependencies": {
         "axios": "^1.6.4",

--- a/package.json
+++ b/package.json
@@ -1,27 +1,26 @@
 {
-  "private": true,
-  "scripts": {
-    "dev": "npm run development",
-    "development": "mix",
-    "watch": "mix watch",
-    "watch-poll": "mix watch -- --watch-options-poll=1000",
-    "hot": "mix watch --hot",
-    "prod": "npm run production",
-    "production": "mix --production"
-  },
-  "devDependencies": {
-    "axios": "^1.6.4",
-    "jquery": "^3.7.1",
-    "laravel-mix": "^6.0.49",
-    "laravel-vite-plugin": "^1.0",
-    "resolve-url-loader": "^5.0.0",
-    "sass": "^1.75.0",
-    "sass-loader": "^14.2.1",
-    "vite": "^5.0"
-  },
-  "dependencies": {
-    "bootstrap": "^5.3.3",
-    "bootstrap-icons": "^1.11.3",
-    "codemirror": "^6.0.1"
-  }
+    "private": true,
+    "scripts": {
+        "dev": "npm run development",
+        "development": "mix",
+        "watch": "mix watch",
+        "watch-poll": "mix watch -- --watch-options-poll=1000",
+        "hot": "mix watch --hot",
+        "prod": "npm run production",
+        "production": "mix --production"
+    },
+    "devDependencies": {
+        "axios": "^1.6.4",
+        "jquery": "^3.7.1",
+        "laravel-vite-plugin": "^0.6.0",
+        "resolve-url-loader": "^5.0.0",
+        "sass": "^1.75.0",
+        "sass-loader": "^14.2.1",
+        "vite": "^3.0.2"
+    },
+    "dependencies": {
+        "bootstrap": "^5.3.3",
+        "bootstrap-icons": "^1.11.3",
+        "codemirror": "^6.0.1"
+    }
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite';
+import laravel from 'laravel-vite-plugin';
+
+export default defineConfig({
+    plugins: [
+        laravel({
+            input: ['resources/css/app.css', 'resources/js/app.js'],
+            refresh: true,
+        }),
+    ],
+});


### PR DESCRIPTION
This pull request includes changes for migrating from Laravel Mix to Vite outlined in [Migration Guide](https://github.com/laravel/vite-plugin/blob/main/UPGRADE.md#migrating-from-laravel-mix-to-vite) and automated by the [Vite Converter](https://laravelshift.com/convert-laravel-mix-to-vite).

**Before merging**, you need to:

- Checkout the `shift-135497` branch
- Run `composer update`
- Run `npm install`
- Review **all** comments for additional changes 
- Thoroughly test your application ([no tests?](https://laravelshift.com/laravel-test-generator), [no CI?](https://laravelshift.com/ci-generator))

Please send your feedback to shift@laravelshift.com or share the good vibes on [Twitter](https://twitter.com/laravelshift).
